### PR TITLE
review of PR 1030

### DIFF
--- a/doc/source/structures/celestial_bodies/body.rst
+++ b/doc/source/structures/celestial_bodies/body.rst
@@ -58,6 +58,7 @@ All of the main celestial bodies in the game are reserved variable names. The fo
     :attr:`ANGULARVEL`               :struct:`Direction` in :ref:`SHIP-RAW <ship-raw>`
     :attr:`GEOPOSITIONOF`            :struct:`GeoCoordinates` in :ref:`SHIP-RAW <ship-raw>`
     :attr:`ALTITUDEOF`               scalar (m)
+    :attr:`SOIRADIUS`                scalar (m)
     ================================ ============
 
 .. attribute:: Body:NAME
@@ -106,3 +107,6 @@ All of the main celestial bodies in the game are reserved variable names. The fo
 
     The altitude of the given vector position, above this body's 'sea level'.  SHIP:BODY:ALTITUDEOF(SHIP:POSITION) should, in principle, give the same thing as SHIP:ALTITUDE.  Example: Eve:ALTITUDEOF(GILLY:POSITION) gives the altitude of gilly's current position above Eve, even if you're not actually anywhere near the SOI of Eve at the time.  Be careful not to confuse this with :ALTITUDE (no "OF" in the name), which is also a suffix of Body by virtue of the fact that Body is an Orbitable, but it doesn't mean the same thing.
 
+.. attribute:: Body:SOIRADIUS
+
+    The radius of the body's sphere of influence. Measured from the body's center.

--- a/kerboscript_tests/lib/testlibpid.ks
+++ b/kerboscript_tests/lib/testlibpid.ks
@@ -39,7 +39,7 @@ declare function display_block {
     startCol, startRow. // define where the block of text should be positioned
 
   print round(seekAlt,2) + "m    " at (startCol,startRow).
-  print round(alt_radar,2) + "m    " at (startCol,startRow+1).
+  print round(alt:radar,2) + "m    " at (startCol,startRow+1).
   print round(myth,3) + "      " at (startCol,startRow+3).
 }.
 
@@ -55,7 +55,7 @@ set hoverPID to pid_init( 0.05, 0.01, 0.1 ). // Kp, Ki, Kd vals.
 gear on.  gear off. // on then off because of the weird KSP 'have to hit g twice' bug.
 
 until gear {
-  set myTh to pid_seek( hoverPID, seekAlt, alt_radar ).
+  set myTh to pid_seek( hoverPID, seekAlt, alt:radar ).
   display_block(18,11).
   wait 0.001.
 }.
@@ -64,4 +64,3 @@ set ship:control:pilotmainthrottle to throttle.
 print "------------------------------".
 print "Releasing control back to you.".
 print "------------------------------".
-

--- a/src/kOS.Safe/Compilation/KS/Compiler.cs
+++ b/src/kOS.Safe/Compilation/KS/Compiler.cs
@@ -36,7 +36,7 @@ namespace kOS.Safe.Compilation.KS
         private CompilerOptions options;
         private const bool TRACE_PARSE = false; // set to true to Debug Log each ParseNode as it's visited.
 
-        private readonly Dictionary<string, string> functionsOverloads = new Dictionary<string, string>
+        private readonly Dictionary<string, string> functionsOverloads = new Dictionary<string, string> // TODO: remove this
         { 
         };
         

--- a/src/kOS.Safe/Compilation/KS/Compiler.cs
+++ b/src/kOS.Safe/Compilation/KS/Compiler.cs
@@ -38,8 +38,6 @@ namespace kOS.Safe.Compilation.KS
 
         private readonly Dictionary<string, string> functionsOverloads = new Dictionary<string, string>
         { 
-            { "round|1", "roundnearest" },
-            { "round|2", "round"} 
         };
         
         private enum StorageModifier {

--- a/src/kOS.Safe/Compilation/KS/Compiler.cs
+++ b/src/kOS.Safe/Compilation/KS/Compiler.cs
@@ -36,10 +36,6 @@ namespace kOS.Safe.Compilation.KS
         private CompilerOptions options;
         private const bool TRACE_PARSE = false; // set to true to Debug Log each ParseNode as it's visited.
 
-        private readonly Dictionary<string, string> functionsOverloads = new Dictionary<string, string> // TODO: remove this
-        { 
-        };
-        
         private enum StorageModifier {
             /// <summary>The storage will definitely be at the localmost scope.</summary>
             LOCAL,
@@ -1283,7 +1279,6 @@ namespace kOS.Safe.Compilation.KS
         {
             NodeStartHousekeeping(node);
 
-            int parameterCount = 0;
             ParseNode trailerNode = node; // the function_trailer rule is here.
 
             // Need to tell OpcodeCall where in the stack the bottom of the arg list is.
@@ -1293,9 +1288,6 @@ namespace kOS.Safe.Compilation.KS
 
             if (trailerNode.Nodes[1].Token.Type == TokenType.arglist)
             {
-
-                parameterCount = (trailerNode.Nodes[1].Nodes.Count / 2) + 1;
-
                 bool remember = identifierIsSuffix;
                 identifierIsSuffix = false;
 
@@ -1306,28 +1298,15 @@ namespace kOS.Safe.Compilation.KS
 
             if (isDirect)
             {
-                string functionName = directName;
-
-                string overloadedFunctionName = GetFunctionOverload(functionName, parameterCount);
-                if (options.FuncManager.Exists(overloadedFunctionName)) // if the name is a built-in, then add the "()" after it.
-                    overloadedFunctionName += "()";
-                AddOpcode(new OpcodeCall(overloadedFunctionName));
+                if (options.FuncManager.Exists(directName)) // if the name is a built-in, then add the "()" after it.
+                    directName += "()";
+                AddOpcode(new OpcodeCall(directName));
             }
             else
             {
-                OpcodeCall op = new OpcodeCall(string.Empty) { Direct = false };
+                var op = new OpcodeCall(string.Empty) { Direct = false };
                 AddOpcode(op);
             }
-        }
-
-        private string GetFunctionOverload(string functionName, int parameterCount)
-        {
-            string functionKey = string.Format("{0}|{1}", functionName, parameterCount);
-            if (functionsOverloads.ContainsKey(functionKey))
-            {
-                return functionsOverloads[functionKey];
-            }
-            return functionName;
         }
 
         private void VisitArgList(ParseNode node)

--- a/src/kOS.Safe/Exceptions/KOSArgumentMismatchException.cs
+++ b/src/kOS.Safe/Exceptions/KOSArgumentMismatchException.cs
@@ -34,7 +34,7 @@ namespace kOS.Safe.Exceptions
         /// <summary>
         /// Describe an error in the number of arguments.
         /// </summary>
-        /// <param name="expected">number of expected arguments</param>
+        /// <param name="expected">a list of the expected arguments</param>
         /// <param name="actual">number of actual arguments</param>
         /// <param name="message">optional message</param>
         public KOSArgumentMismatchException(IList<int> expected, int actual, string message = "" ) :
@@ -53,7 +53,7 @@ namespace kOS.Safe.Exceptions
         
         private static string BuildTerseMessage(IList<int> expected, int actual)
         {
-            var expectedDisplay = (expected.Any() ? "no" : String.Join(", ", new List<int>(expected).ConvertAll(i => i.ToString()).ToArray()));
+            var expectedDisplay = (expected.Any() ? String.Join(", ", new List<int>(expected).ConvertAll(i => i.ToString()).ToArray()) : "no");
             var pluralDecorator = (expected.Count() == 1 ? "" : "s");
             var actualArgs = (actual == 0 ? "none" : actual.ToString());
 

--- a/src/kOS.Safe/Exceptions/KOSArgumentMismatchException.cs
+++ b/src/kOS.Safe/Exceptions/KOSArgumentMismatchException.cs
@@ -5,7 +5,7 @@ using System.Linq;
 namespace kOS.Safe.Exceptions
 {
     /// <summary>
-    /// Indicates that a method or function was called with the 
+    /// Indicates that a method or function was called with the
     /// wrong number of arguments.
     /// </summary>
     public class KOSArgumentMismatchException : KOSException
@@ -19,15 +19,15 @@ namespace kOS.Safe.Exceptions
         {
             get { return string.Empty; }
         }
-        
+
         /// <summary>
         /// Describe an error in the number of arguments.
         /// </summary>
         /// <param name="expected">number of expected arguments</param>
         /// <param name="actual">number of actual arguments</param>
         /// <param name="message">optional message</param>
-        public KOSArgumentMismatchException(int expected, int actual, string message = "" ) :
-            base( BuildTerseMessage(new[] {expected},actual) + message )
+        public KOSArgumentMismatchException(int expected, int actual, string message = "") :
+            this(new[] { expected }, actual, message)
         {
         }
 
@@ -37,35 +37,35 @@ namespace kOS.Safe.Exceptions
         /// <param name="expected">a list of the expected arguments</param>
         /// <param name="actual">number of actual arguments</param>
         /// <param name="message">optional message</param>
-        public KOSArgumentMismatchException(IList<int> expected, int actual, string message = "" ) :
-            base( BuildTerseMessage(expected,actual) + message )
+        public KOSArgumentMismatchException(IList<int> expected, int actual, string message = "") :
+            base(string.Format("{0} {1}", BuildTerseMessage(expected, actual), message))
         {
         }
 
         /// <summary>
-        /// Describe an error in the number of arguments, without knowing the number of args
+        /// Describe an error in the number of arguments, without knowing the number of arguments
         /// </summary>
         /// <param name="message">optional message</param>
         public KOSArgumentMismatchException(string message = "") :
-            base( BuildTerseMessage() + " " + message )
+            base(string.Format("{0} {1}", BuildTerseMessage(), message))
         {
         }
-        
+
         private static string BuildTerseMessage(IList<int> expected, int actual)
         {
             var expectedDisplay = (expected.Any() ? String.Join(", ", new List<int>(expected).ConvertAll(i => i.ToString()).ToArray()) : "no");
             var pluralDecorator = (expected.Count() == 1 ? "" : "s");
             var actualArgs = (actual == 0 ? "none" : actual.ToString());
 
-            return string.Format("Incorrect number of arguments.  Expected {0} argument{1}, but found {2}",
-                                 expectedDisplay, pluralDecorator, actualArgs );
+            return string.Format("Incorrect number of arguments.  Expected {0} argument{1}, but found {2}.",
+                                 expectedDisplay, pluralDecorator, actualArgs);
         }
 
         private static string BuildTerseMessage()
         {
             return String.Format("Number of arguments passed to the function didn't match the number of DECLARE PARAMETERs encountered.");
         }
-        
+
         private string BuildVerboseMessage()
         {
             return

--- a/src/kOS.Safe/Exceptions/KOSArgumentMismatchException.cs
+++ b/src/kOS.Safe/Exceptions/KOSArgumentMismatchException.cs
@@ -1,4 +1,6 @@
 ﻿using System;
+using System.Collections.Generic;
+using System.Linq;
 
 namespace kOS.Safe.Exceptions
 {
@@ -18,9 +20,6 @@ namespace kOS.Safe.Exceptions
             get { return string.Empty; }
         }
         
-        private int expectedNum;
-        private int actualNum;
-        
         /// <summary>
         /// Describe an error in the number of arguments.
         /// </summary>
@@ -28,10 +27,19 @@ namespace kOS.Safe.Exceptions
         /// <param name="actual">number of actual arguments</param>
         /// <param name="message">optional message</param>
         public KOSArgumentMismatchException(int expected, int actual, string message = "" ) :
+            base( BuildTerseMessage(new[] {expected},actual) + message )
+        {
+        }
+
+        /// <summary>
+        /// Describe an error in the number of arguments.
+        /// </summary>
+        /// <param name="expected">number of expected arguments</param>
+        /// <param name="actual">number of actual arguments</param>
+        /// <param name="message">optional message</param>
+        public KOSArgumentMismatchException(IList<int> expected, int actual, string message = "" ) :
             base( BuildTerseMessage(expected,actual) + message )
         {
-            expectedNum = expected;
-            actualNum = actual;
         }
 
         /// <summary>
@@ -41,15 +49,16 @@ namespace kOS.Safe.Exceptions
         public KOSArgumentMismatchException(string message = "") :
             base( BuildTerseMessage() + " " + message )
         {
-            expectedNum = 0;
-            actualNum = 0;
         }
         
-        private static string BuildTerseMessage(int expected, int actual)
+        private static string BuildTerseMessage(IList<int> expected, int actual)
         {
-            return String.Format("Incorrect number of arguments.  Expected {0} argument{1}, but found {2}",
-                                 (expected==0?"no":expected.ToString()), (expected==1?"":"s"), (actual==0?"none":actual.ToString())
-                                );
+            var expectedDisplay = (expected.Any() ? "no" : String.Join(", ", new List<int>(expected).ConvertAll(i => i.ToString()).ToArray()));
+            var pluralDecorator = (expected.Count() == 1 ? "" : "s");
+            var actualArgs = (actual == 0 ? "none" : actual.ToString());
+
+            return string.Format("Incorrect number of arguments.  Expected {0} argument{1}, but found {2}",
+                                 expectedDisplay, pluralDecorator, actualArgs );
         }
 
         private static string BuildTerseMessage()

--- a/src/kOS/Function/Math.cs
+++ b/src/kOS/Function/Math.cs
@@ -62,7 +62,7 @@ namespace kOS.Function
         {
             int argc = CountRemainingArgs(shared);
             int decimals = 0;
-            if argc >= 2
+            if (argc >= 2)
             {
               decimals = GetInt(PopValueAssert(shared));
             }

--- a/src/kOS/Function/Math.cs
+++ b/src/kOS/Function/Math.cs
@@ -60,12 +60,21 @@ namespace kOS.Function
     {
         public override void Execute(SharedObjects shared)
         {
-            int argc = CountRemainingArgs(shared);
-            int decimals = 0;
-            if (argc >= 2)
+            int decimals;
+            int argCount = CountRemainingArgs(shared);
+
+            switch (argCount)
             {
-              decimals = GetInt(PopValueAssert(shared));
+                case 1:
+                    decimals = 0;
+                    break;
+                case 2:
+                    decimals = GetInt(PopValueAssert(shared));
+                    break;
+                default:
+                    throw new KOSArgumentMismatchException(new []{1,2}, argCount);
             }
+
             double argument = GetDouble(PopValueAssert(shared));
             AssertArgBottomAndConsume(shared);
             double result = Math.Round(argument, decimals);

--- a/src/kOS/Function/Math.cs
+++ b/src/kOS/Function/Math.cs
@@ -55,24 +55,17 @@ namespace kOS.Function
         }
     }
 
-    [Function("roundnearest")]
-    public class FunctionRoundNearest : FunctionBase
-    {
-        public override void Execute(SharedObjects shared)
-        {
-            double argument = GetDouble(PopValueAssert(shared));
-            AssertArgBottomAndConsume(shared);
-            double result = Math.Round(argument);
-            ReturnValue = result;
-        }
-    }
-
     [Function("round")]
     public class FunctionRound : FunctionBase
     {
         public override void Execute(SharedObjects shared)
         {
-            int decimals = GetInt(PopValueAssert(shared));
+            int argc = CountRemainingArgs(shared);
+            int decimals = 0;
+            if argc >= 2
+            {
+              decimals = GetInt(PopValueAssert(shared));
+            }
             double argument = GetDouble(PopValueAssert(shared));
             AssertArgBottomAndConsume(shared);
             double result = Math.Round(argument, decimals);


### PR DESCRIPTION
- removes compiler.functionsOverloads and the code that used it
- enhances KOSArgumentMismatchException to allow for multiple expected args
- changes round() to throw on an invalid number of args
